### PR TITLE
Add TIER_ORDER and purchases category with batch upsert and error handling

### DIFF
--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -36,6 +36,14 @@ export const TIER_EMOJI: Record<string, string> = {
   diamond: "\u{1F48E}", // gem
 };
 
+/** Numeric order for sorting tiers lowest → highest. */
+export const TIER_ORDER: Record<string, number> = {
+  bronze: 0,
+  silver: 1,
+  gold: 2,
+  diamond: 3,
+};
+
 // ─── Core Logic ──────────────────────────────────────────────
 
 interface DevStats {
@@ -49,6 +57,8 @@ interface DevStats {
   app_streak?: number;
   kudos_streak?: number;
   raid_xp?: number;
+  /** Number of shop items purchased (paid or free). */
+  purchases?: number;
 }
 
 /**
@@ -105,6 +115,8 @@ export async function checkAchievements(
         return (stats.kudos_streak ?? 0) >= a.threshold;
       case "raid":
         return (stats.raid_xp ?? 0) >= a.threshold;
+      case "purchases":
+        return (stats.purchases ?? 0) >= a.threshold;
       default:
         return false;
     }
@@ -138,10 +150,10 @@ export async function checkAchievements(
       status: "completed",
     }));
 
-    // Insert one by one, skip if already owned (unique index handles dedup)
-    for (const row of purchaseRows) {
-      await sb.from("purchases").insert(row);
-    }
+    // Batch upsert — unique index on (developer_id, item_id) prevents duplicates
+    await sb
+      .from("purchases")
+      .upsert(purchaseRows, { onConflict: "developer_id,item_id" });
   }
 
   // Insert feed events
@@ -174,20 +186,30 @@ export async function checkAchievements(
     });
   }
 
-  // Notify developer of gold/diamond achievements
+  // Notify developer of gold/diamond achievements (fire-and-forget)
   if (actorLogin) {
-    sendAchievementNotification(
-      developerId,
-      actorLogin,
-      newUnlocks.map((a) => ({ id: a.id, name: a.name, tier: a.tier })),
-    );
+    void (async () => {
+      try {
+        sendAchievementNotification(
+          developerId,
+          actorLogin,
+          newUnlocks.map((a) => ({ id: a.id, name: a.name, tier: a.tier })),
+        );
+      } catch (err: unknown) {
+        console.error("[achievements] notification failed", err);
+      }
+    })();
   }
 
   return newUnlocks.map((a) => a.id);
 }
 
+/** Max IDs per Supabase `.in()` query to avoid URL length limits. */
+const CHUNK_SIZE = 500;
+
 /**
  * Batch fetch achievements for multiple developers (for city API).
+ * Automatically chunks large ID arrays to stay within Supabase query limits.
  */
 export async function getAchievementsForDevelopers(
   developerIds: number[]
@@ -195,13 +217,27 @@ export async function getAchievementsForDevelopers(
   if (developerIds.length === 0) return {};
 
   const sb = getSupabaseAdmin();
-  const { data } = await sb
-    .from("developer_achievements")
-    .select("developer_id, achievement_id")
-    .in("developer_id", developerIds);
+
+  // Split into chunks to avoid Supabase .in() URL length limits
+  const chunks: number[][] = [];
+  for (let i = 0; i < developerIds.length; i += CHUNK_SIZE) {
+    chunks.push(developerIds.slice(i, i + CHUNK_SIZE));
+  }
+
+  const rows = (
+    await Promise.all(
+      chunks.map((chunk) =>
+        sb
+          .from("developer_achievements")
+          .select("developer_id, achievement_id")
+          .in("developer_id", chunk)
+          .then(({ data }) => data ?? [])
+      )
+    )
+  ).flat();
 
   const result: Record<number, string[]> = {};
-  for (const row of data ?? []) {
+  for (const row of rows) {
     if (!result[row.developer_id]) result[row.developer_id] = [];
     result[row.developer_id].push(row.achievement_id);
   }


### PR DESCRIPTION
This pull request enhances the achievements logic in `src/lib/achievements.ts` by improving performance, expanding achievement criteria, and increasing reliability. The most significant changes include adding support for purchase-based achievements, optimizing database operations with batch upserts, chunking large queries to avoid Supabase URL limits, and making notification delivery more robust.

**Achievement logic and criteria improvements:**
* Added support for purchase-based achievements by introducing a `purchases` field to `DevStats` and updating the `checkAchievements` function to handle the new "purchases" criterion. [[1]](diffhunk://#diff-fbbeb57a34e75a760f379e3541b5d5cfa2a485832f3b4d5d8b3da0652fe5c3eaR60-R61) [[2]](diffhunk://#diff-fbbeb57a34e75a760f379e3541b5d5cfa2a485832f3b4d5d8b3da0652fe5c3eaR118-R119)
* Introduced `TIER_ORDER` to provide a numeric order for sorting achievement tiers.

**Database performance and reliability:**
* Optimized achievement purchase recording by switching from row-by-row inserts to a batch upsert, preventing duplicates via a unique index.
* Improved batch fetching of achievements for multiple developers by chunking large ID arrays to avoid Supabase `.in()` query URL length limits.

**Notification delivery:**
* Made achievement notification delivery fire-and-forget with error handling to prevent notification failures from blocking the main process.…, chunked fetch and safe notification error handling

