### PR TITLE
🐛 fix(rate-limit): skip quota for existing devs and only record on success

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { createServerSupabase } from "@/lib/supabase-server";
 import type { TopRepo } from "@/lib/github";
 
-// ─── Rate Limiting ───────────────────────────────────────────
-
-async function hashIP(ip: string): Promise<string> {
-  const data = new TextEncoder().encode(ip + (process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""));
+async function hashKey(key: string): Promise<string> {
+  const data = new TextEncoder().encode(key + (process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""));
   const buf = await crypto.subtle.digest("SHA-256", data);
   return Array.from(new Uint8Array(buf))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 }
 
-async function checkRateLimit(ip: string): Promise<boolean> {
+async function isRateLimited(key: string): Promise<boolean> {
   const sb = getSupabaseAdmin();
-  const ipHash = await hashIP(ip);
+  const ipHash = await hashKey(key);
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 
   const { count } = await sb
@@ -23,13 +22,14 @@ async function checkRateLimit(ip: string): Promise<boolean> {
     .eq("ip_hash", ipHash)
     .gte("created_at", oneHourAgo);
 
-  if ((count ?? 0) >= 10) return false;
-
-  await sb.from("add_requests").insert({ ip_hash: ipHash });
-  return true;
+  return (count ?? 0) >= 10;
 }
 
-// ─── GitHub Fetching ─────────────────────────────────────────
+async function recordRateLimitRequest(key: string): Promise<void> {
+  const sb = getSupabaseAdmin();
+  const ipHash = await hashKey(key);
+  await sb.from("add_requests").insert({ ip_hash: ipHash });
+}
 
 function ghHeaders(): HeadersInit {
   const h: HeadersInit = {
@@ -230,7 +230,6 @@ export async function GET(
   const { username } = await params;
   const sb = getSupabaseAdmin();
 
-  // Check cache first (no rate limit cost)
   const { data: cached } = await sb
     .from("developers")
     .select("*")
@@ -248,15 +247,31 @@ export async function GET(
     }
   }
 
-  // Only rate limit when we need to fetch from GitHub
-  if (process.env.NODE_ENV !== "development") {
-    const ip =
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      request.headers.get("x-real-ip") ??
-      "unknown";
+  // Rate limit only applies to brand-new developers (not in DB at all).
+  // Stale refreshes for existing devs are unlimited ("already in the city").
+  let rateLimitKey: string | null = null;
+  if (process.env.NODE_ENV !== "development" && !cached) {
+    // Auth user ID is preferred over IP to avoid shared-IP false positives
+    // (e.g. users behind the same corporate/university NAT sharing a quota).
+    let key: string;
+    try {
+      const authClient = await createServerSupabase();
+      const { data: { user } } = await authClient.auth.getUser();
+      key = user ? `user:${user.id}` : (
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+        request.headers.get("x-real-ip") ??
+        "unknown"
+      );
+    } catch {
+      key =
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+        request.headers.get("x-real-ip") ??
+        "unknown";
+    }
 
-    const allowed = await checkRateLimit(ip);
-    if (!allowed) {
+    rateLimitKey = key;
+    const limited = await isRateLimited(key);
+    if (limited) {
       return NextResponse.json(
         { error: "Rate limit exceeded. Max 10 lookups per hour." },
         { status: 429 }
@@ -264,7 +279,6 @@ export async function GET(
     }
   }
 
-  // Fetch from GitHub
   try {
     const headers = ghHeaders();
 
@@ -379,6 +393,11 @@ export async function GET(
         language: r.language,
         url: r.html_url,
       }));
+
+    // Record after validation so failed lookups (typos, orgs) don't burn slots.
+    if (rateLimitKey) {
+      await recordRateLimitRequest(rateLimitKey);
+    }
 
     // Upsert into Supabase
     const record = {


### PR DESCRIPTION
## What does this PR do?

Fixes the rate limit being triggered for users who are already in the city — including when searching yourself.

Three bugs in the original `checkRateLimit` function:

1. **Stale refreshes counted as new lookups** — if a developer existed in the DB but their data was >24h old, re-fetching them consumed a rate limit slot. The message says _"Developers already in the city are unlimited"_ but the code didn't honor that for stale records.
2. **Failed lookups burned slots** — the `add_requests` row was inserted before the GitHub fetch, so typos, org accounts, and no-activity users all consumed a slot even though nothing was added to the city.
3. **Shared-IP false positives** — users behind the same corporate/university NAT shared a single 10/hr quota. An authenticated user's Supabase ID is now used as the rate limit key instead of IP.

### Before / After

| Scenario | Before | After |
|---|---|---|
| First-time search (not in DB) | 200, 0→1 slot | 200, 0→1 slot |
| Search again (cached <24h) | 200, 1→1 | 200, 1→1 |
| **Stale refresh >24h (reported bug)** | **200, 1→2** 🐛 | **200, 1→1** ✅ |
| **Typo / nonexistent user** | **404, 2→3** 🐛 | **404, 1→1** ✅ |
| 11th brand-new user | 429 | 429 |

## Related issue

Fixes #12

## Screenshots

N/A — API-only change.

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed