### PR TITLE
🚧 chore: add SECURITY.md with vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported Versions
+
+Git City is actively developed. Security fixes are applied to the latest version on `main`.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest (`main`) | :white_check_mark: |
+| older commits   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in Git City, please **do not** open a public GitHub issue.
+
+### How to Report
+
+Please report vulnerabilities by emailing the maintainer directly or using GitHub's private security advisory feature:
+
+1. Go to the [Security Advisories](https://github.com/srizzon/git-city/security/advisories) page
+2. Click **"Report a vulnerability"**
+3. Fill in the details of the issue
+
+Alternatively, you can reach out to the maintainer via [X/Twitter](https://x.com/samuelrizzondev).
+
+### What to Include
+
+Please include as much of the following information as possible to help us understand and resolve the issue quickly:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any proof-of-concept or exploit code (if applicable)
+- Affected component(s) (e.g., auth flow, API route, Supabase RLS policy)
+
+## Sensitive Areas
+
+Git City handles the following sensitive data — please pay special attention when auditing:
+
+- **GitHub OAuth tokens** — used for authentication via Supabase
+- **Supabase Row Level Security (RLS)** — controls data access per user
+- **Stripe payment webhooks** — handles payment events
+- **API routes** — under `src/app/api/` — ensure proper authentication checks
+- **CRON endpoints** — protected by `CRON_SECRET`; unauthorized access could trigger unintended server actions
+
+## Response Timeline
+
+- **Acknowledgement:** Within 72 hours of receiving a report
+- **Status update:** Within 7 days
+- **Fix or mitigation:** Depends on severity; critical issues will be prioritized
+
+## Disclosure Policy
+
+We follow a **coordinated disclosure** model. Once a fix is available, we will:
+
+1. Publish a GitHub Security Advisory
+2. Credit the reporter (unless they wish to remain anonymous)
+3. Release a patched version
+
+Thank you for helping keep Git City and its users safe!


### PR DESCRIPTION
## What does this PR do?

Adds a `SECURITY.md` file to the repository - a standard community health file that is currently missing. This gives security researchers and contributors a clear process for responsibly disclosing vulnerabilities.

## Why is this needed?

Git City handles sensitive data including:
- GitHub OAuth tokens (via Supabase auth)
- Stripe payment webhooks
- Supabase RLS policies protecting user data
- CRON endpoints protected by secret keys

Without a security policy, there is no guidance for how to report vulnerabilities, which could lead to public disclosure before a fix is available.

## What is included?

- Supported versions table
- Step-by-step vulnerability reporting instructions (GitHub private advisory + Twitter/X contact)
- Sensitive areas in the codebase to audit
- Response timeline commitments (72h ack, 7 day updates)
- Coordinated disclosure policy

## Related issue

N/A - This is a proactive improvement to the project community health files.

## Checklist

- [x] No code changes - documentation only
- [x] Follows the project existing community file style
- [x] Links to correct upstream maintainer contact info