### PR TITLE
✏️ docs(contributing): add env vars table and troubleshooting section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,27 @@ The app runs on [http://localhost:3001](http://localhost:3001).
 - A GitHub personal access token (for API calls)
 - Stripe test keys (only if working on payments)
 
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in the values. Here is a summary of what each variable does:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `NEXT_PUBLIC_BASE_URL` | Yes | Base URL for the app (e.g. `http://localhost:3001` locally) |
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes | Your Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anonymous/public key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase service role key (server-side only, keep secret) |
+| `GITHUB_TOKEN` | Yes | GitHub personal access token for API calls |
+| `STRIPE_SECRET_KEY` | Optional | Stripe secret key — only needed for payment features |
+| `STRIPE_WEBHOOK_SECRET` | Optional | Stripe webhook secret — only needed for payment features |
+| `ABACATEPAY_API_KEY` | Optional | AbacatePay key — only needed for BRL payment support |
+| `ABACATEPAY_WEBHOOK_SECRET` | Optional | AbacatePay webhook secret |
+| `NEXT_PUBLIC_HIMETRICA_API_KEY` | Optional | Himetrica analytics key |
+| `RESEND_API_KEY` | Optional | Resend email key — used for ad expiry notification emails |
+| `CRON_SECRET` | Optional | Secret token to authenticate Vercel cron job requests |
+
+> **Tip:** For local development you only need the Supabase, GitHub token, and base URL variables. Stripe, AbacatePay, Resend, and Himetrica keys are only required if you are actively working on those features.
+
 ## Code Style
 
 - TypeScript everywhere
@@ -46,7 +67,7 @@ Run `npm run lint` before submitting.
 Start with an emoji + type. Single line, present tense, concise.
 
 | Emoji | Type | When |
-|-------|------|------|
+| --- | --- | --- |
 | ✨ | `feat` | New features |
 | 🐛 | `fix` | Bug fixes |
 | 📦 | `refactor` | Code restructuring |
@@ -96,6 +117,20 @@ The city is rendered with React Three Fiber. Key files:
 - `src/lib/zones.ts` - Item definitions for building customization
 
 If you're adding a new building effect or item, start with `zones.ts`.
+
+## Troubleshooting
+
+**`npm run dev` fails with a Supabase error**
+Make sure `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set correctly in `.env.local`.
+
+**GitHub API rate limit errors**
+Ensure `GITHUB_TOKEN` is a valid personal access token with at least `read:user` and `public_repo` scopes.
+
+**Port 3001 already in use**
+Kill the process using port 3001, or change `NEXT_PUBLIC_BASE_URL` and the dev server port in `package.json`.
+
+**TypeScript errors after pulling latest changes**
+Run `npm install` to pick up any new dependencies, then `npm run lint` to surface type issues.
 
 ## Questions?
 


### PR DESCRIPTION
## What does this PR do?

Improves `CONTRIBUTING.md` with two key additions:

1. **Environment Variables table** - Documents all 12 env vars from `.env.example` (previously undocumented), with Required/Optional status and descriptions. New contributors no longer need to guess what each variable does.

2. **Troubleshooting section** - Covers the 4 most common local dev issues: Supabase config errors, GitHub token rate limits, port conflicts, and TypeScript errors after pulling.

## Why is this needed?

The current `CONTRIBUTING.md` mentions `.env.example` but only lists 4 of the required services (Supabase, GitHub, Stripe, Node). There are 12 environment variables in total including `ABACATEPAY_API_KEY`, `RESEND_API_KEY`, `CRON_SECRET`, `HIMETRICA_API_KEY` etc. that are completely undocumented for contributors. This friction makes local setup harder than it needs to be.

## Related issue

N/A - This is a documentation improvement.

## Checklist

- [x] No code changes - documentation only
- [x] All env vars cross-referenced against `.env.example`
- [x] Troubleshooting tips are accurate to the project setup