### PR TITLE
docs: add Windows command for .env file setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,16 @@ cd git-city
 npm install
 
 # Set up environment variables
-cp .env.example .env.local ( linux ) | copy .env.example .env.local ( windows )
+
+# Linux / macOS
+cp .env.example .env.local
+
+# Windows (Command Prompt)
+copy .env.example .env.local
+
+# Windows (PowerShell)
+Copy-Item .env.example .env.local
+
 # Fill in Supabase and Stripe keys
 
 # Run the dev server


### PR DESCRIPTION
Added Windows command for copying .env.example to .env.local
in README since cp only works on Linux/macOS.