### PR TITLE
🐛 fix(fly-mode): auto-pause/resume flight when landmark modal opens and close with single ESC

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -838,7 +838,7 @@ function HomeContent() {
   // During fly mode: only close overlays (profile card) — AirplaneFlight handles pause/exit
   // Outside fly mode: compare → share modal → profile card → focus → explore mode
   useEffect(() => {
-    if (flyMode && !selectedBuilding) return;
+    if (flyMode && !selectedBuilding && !pillModalOpen && !founderMessageOpen) return;
     if (!flyMode && !exploreMode && !focusedBuilding && !shareData && !selectedBuilding && !giftClaimed && !giftModalOpen && !comparePair && !compareBuilding && !founderMessageOpen && !pillModalOpen && !rabbitCinematic && raidState.phase === "idle") return;
     const onKey = (e: KeyboardEvent) => {
       if (e.code === "Escape") {
@@ -1871,7 +1871,7 @@ if (claimingGift) return;
         accentColor={theme.accent}
         onClearFocus={() => setFocusedBuilding(null)}
         flyPauseSignal={flyPauseSignal}
-        flyHasOverlay={!!selectedBuilding}
+        flyHasOverlay={!!selectedBuilding || pillModalOpen || founderMessageOpen || rabbitCinematic}
         flyStartPaused={showFlyControls}
         holdRise={loadStage !== "done"}
         celebrationActive={celebrationActive}

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect, useState, useMemo } from "react";
+import { useRef, useEffect, useEffectEvent, useState, useMemo } from "react";
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF, Stats, PerformanceMonitor } from "@react-three/drei";
 import { EffectComposer, Bloom } from "@react-three/postprocessing";
@@ -649,6 +649,30 @@ function AirplaneFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = 
       }
     }
   }, [pauseSignal, onPause]);
+
+  // Auto-pause when an overlay opens, auto-resume when it closes.
+  // useEffectEvent gives a stable identity that always reads the latest onPause
+  // without adding it to the effect's dependency array.
+  const notifyPause = useEffectEvent((p: boolean) => onPause(p));
+  useEffect(() => {
+    if (hasOverlay) {
+      if (!paused.current) {
+        paused.current = true;
+        setIsPaused(true);
+        notifyPause(true);
+      }
+    } else {
+      if (paused.current) {
+        paused.current = false;
+        setIsPaused(false);
+        wasJustUnpaused.current = true;
+        transitionProgress.current = 0;
+        transitionFrom.current.copy(camera.position);
+        transitionLookFrom.current.copy(camLook.current);
+        notifyPause(false);
+      }
+    }
+  }, [hasOverlay]);
 
   // Keyboard
   const hasOverlayRef = useRef(hasOverlay);


### PR DESCRIPTION
## What does this PR do?

Fixes the landmark modal (\"Make Your Choice\") requiring **3 ESC presses** to close while in Fly Mode, and exiting Fly Mode as a side-effect before the modal closed.

Three bugs combined to cause this:

1. **`page.tsx` ESC handler never registered during fly mode with no selected building** — the early-return guard `if (flyMode && !selectedBuilding) return` exited the `useEffect` setup before `addEventListener` was called, so the handler that calls `setPillModalOpen(false)` was never attached.

2. **`flyHasOverlay` didn't include the pill/founder/rabbit modals** — `AirplaneFlight` thought no overlay was present while paused, so the second ESC called `onExit()` (exiting fly mode) instead of deferring.

3. **No auto-pause/resume on modal open/close** — clicking the landmark building during flight didn't pause the flight, and closing the modal didn't resume it.

### Root cause sequence (before fix)

| ESC press | `page.tsx` listener? | `AirplaneFlight` fires? | Result |
|---|---|---|---|
| 1st | Not registered | Yes (flying → pause) | Flight pauses; modal stays open |
| 2nd | Not registered | Yes (paused, `hasOverlay=false` → exit) | Fly mode exits; modal stays open |
| 3rd | Now registered (`flyMode=false`) | No | Modal closes |

### Before / After

| Scenario | Before | After |
|---|---|---|
| Click landmark in fly mode | Flight keeps going, modal opens | Flight pauses, modal opens |
| ESC with modal open | Pauses flight (1st), exits fly mode (2nd), closes modal (3rd) | Closes modal, flight stays paused |
| Close modal (ESC or click outside) | Flight still running or fly mode exited | Flight resumes automatically |
| Choose \"The Rabbit Hole\" | Flight keeps going during rabbit cinematic | Flight pauses for rabbit cinematic too |

## Related issue

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/7aa35db7-4beb-4574-bddd-a30d4d9da630" /> | <video src="https://github.com/user-attachments/assets/dc12b88e-441d-4018-9ca3-a4a98f9cb05c" /> |

## Checklist

- [x] `npm run lint` passes (no new errors introduced)
- [x] Tested locally
- [x] No secrets or .env values committed