### PR TITLE
🐛 fix(dev-api): replace 24h cache gate with GitHub ETag conditional requests and on-demand ISR revalidation

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { createServerSupabase } from "@/lib/supabase-server";
 import type { TopRepo } from "@/lib/github";
@@ -245,17 +246,6 @@ export async function GET(
     .eq("github_login", username.toLowerCase())
     .single();
 
-  if (cached) {
-    const age = Date.now() - new Date(cached.fetched_at).getTime();
-    if (age < 24 * 60 * 60 * 1000) {
-      return NextResponse.json(cached, {
-        headers: {
-          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
-        },
-      });
-    }
-  }
-
   // Rate limit only applies to brand-new developers (not in DB at all).
   // Stale refreshes for existing devs are unlimited ("already in the city").
   const isInternalBackfill =
@@ -303,12 +293,38 @@ export async function GET(
       size: number;
     };
 
+    // ETag conditional request: free 304s don't count against GitHub rate limit.
+    // However, the /users ETag only covers profile fields (name, bio, public_repos).
+    // Contributions (GraphQL) and stars (repos endpoint) have independent freshness,
+    // so a 304 only means "profile unchanged" — we still re-fetch the expensive
+    // pipelines once the cached row is older than FULL_REFRESH_INTERVAL.
+    const FULL_REFRESH_INTERVAL = 60 * 60 * 1000; // 1 hour
+    const cachedAge = cached ? Date.now() - new Date(cached.fetched_at).getTime() : Infinity;
+    const needsFullRefresh = cachedAge >= FULL_REFRESH_INTERVAL;
+
     const userRes = await fetch(
       `https://api.github.com/users/${encodeURIComponent(username)}`,
-      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      {
+        headers: {
+          ...headers,
+          ...(cached?.github_etag ? { "If-None-Match": cached.github_etag } : {}),
+        },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      },
     );
 
-    if (!userRes.ok) {
+    if (userRes.status === 304 && !needsFullRefresh) {
+      return NextResponse.json(cached, {
+        headers: {
+          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+        },
+      });
+    }
+
+    // 304 but contributions/stars may be stale: reuse cached profile fields, re-fetch the rest
+    const profileNotModified = userRes.status === 304;
+
+    if (!profileNotModified && !userRes.ok) {
       if (userRes.status === 404) {
         return NextResponse.json(
           { error: "User not found" },
@@ -327,19 +343,21 @@ export async function GET(
       );
     }
 
-    const ghUser = await userRes.json();
+    const ghUser = profileNotModified ? null : await userRes.json();
 
-    // Reject organizations
-    if (ghUser.type === "Organization") {
+    // Reject organizations (only possible on a fresh 200 response)
+    if (ghUser?.type === "Organization") {
       return NextResponse.json(
         { error: "Organizations are not supported. Search for a user profile instead." },
         { status: 400 }
       );
     }
 
+    const login = ghUser?.login ?? cached!.github_login;
+
     // Fetch expanded GitHub data (GraphQL) and first page of repos in parallel
     const [expanded, reposPage1Res] = await Promise.all([
-      fetchExpandedGitHubData(ghUser.login),
+      fetchExpandedGitHubData(login),
       fetch(
         `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=pushed&per_page=100&page=1`,
         { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
@@ -348,8 +366,10 @@ export async function GET(
 
     const contributions = expanded?.contributions ?? 0;
 
+    const publicRepos = ghUser?.public_repos ?? cached!.public_repos;
+
     // Reject users with zero public activity
-    if (contributions === 0 && ghUser.public_repos === 0) {
+    if (contributions === 0 && publicRepos === 0) {
       return NextResponse.json(
         { error: "This user has no public activity on GitHub yet." },
         { status: 400 }
@@ -410,16 +430,17 @@ export async function GET(
 
     // Upsert into Supabase
     const record = {
-      github_login: ghUser.login.toLowerCase(),
-      github_id: ghUser.id,
-      name: ghUser.name,
-      avatar_url: ghUser.avatar_url,
-      bio: ghUser.bio,
+      github_login: login.toLowerCase(),
+      github_id: ghUser?.id ?? cached!.github_id,
+      name: ghUser?.name ?? cached!.name,
+      avatar_url: ghUser?.avatar_url ?? cached!.avatar_url,
+      bio: ghUser?.bio ?? cached!.bio,
       contributions,
-      public_repos: ghUser.public_repos,
+      public_repos: publicRepos,
       total_stars: totalStars,
       primary_language: primaryLanguage,
       top_repos: topRepos,
+      github_etag: (profileNotModified ? cached?.github_etag : userRes.headers.get("etag")) ?? null,
       fetched_at: new Date().toISOString(),
       // v2 fields
       ...(expanded ? {
@@ -469,7 +490,7 @@ export async function GET(
       const newGithubXp = calculateGithubXp({
         contributions: expanded?.contributions_total ?? contributions,
         total_stars: totalStars,
-        public_repos: ghUser.public_repos,
+        public_repos: publicRepos,
         total_prs: expanded?.total_prs ?? 0,
       });
       const prevGithubXp = (cached?.xp_github as number) ?? 0;
@@ -528,6 +549,8 @@ export async function GET(
       .select("*")
       .eq("github_login", record.github_login)
       .single();
+
+    revalidatePath(`/dev/${record.github_login}`);
 
     return NextResponse.json(withRank ?? upserted, {
       headers: {

--- a/supabase/migrations/036_github_etag.sql
+++ b/supabase/migrations/036_github_etag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE developers ADD COLUMN IF NOT EXISTS github_etag text;


### PR DESCRIPTION
## What does this PR do?

Fixes stale GitHub data (contributions, stars, repos) shown on both the profile page (`/dev/[username]`) and the city popup (`/?user=`).

The root cause was a 24h application-layer time fence that blocked GitHub re-fetches for existing developers, combined with a 1-hour ISR window on the profile page that had no invalidation trigger when data actually changed.

Two bugs combined to cause the mismatch:

1. **24h cache gate swallowed fresh data** — `if (age < 24h) return cached` prevented any re-fetch from GitHub regardless of whether data had actually changed. Reported by `@tonystark-19`: contributions showed 2,317 (Wednesday) on Friday when the real count was 2,327.

2. **Profile page ISR had no on-demand invalidation** — `revalidate = 3600` on `/dev/[username]/page.tsx` meant the page could be up to 1 hour stale with no mechanism to purge it when the underlying DB row changed. This caused the repos count mismatch between `/dev/[username]` (10) and `/?user=` city popup (5).

### What changed

**Replaced** the 24h gate with a **hybrid ETag + time-based** approach, because the `/users` ETag alone is insufficient:

- The `GET /users/{login}` ETag only covers profile fields (name, bio, avatar, `public_repos` count). It does **not** change when contributions are made (GraphQL) or when repo stars change (separate `/repos` endpoint). Verified: `tonystark-19`'s profile `last-modified` is Jan 27 2026, but they've made 205 contributions since then — the ETag would return `304` every time and serve permanently stale data.

The hybrid logic:

| Condition | Action |
|---|---|
| `/users` → `304` AND row < 1h old | Return cached immediately (no rate charge, profile + contributions fresh) |
| `/users` → `304` AND row ≥ 1h old | Reuse cached profile fields, re-fetch GraphQL + repos (contributions/stars updated) |
| `/users` → `200` | Full re-fetch and upsert as normal |

**Added** `revalidatePath(/dev/<login>)` after every successful upsert so the ISR profile page is invalidated on-demand exactly when data changes — fixing the repos count mismatch.

### Before / After

| Scenario | Before | After |
|---|---|---|
| Dev searched, data changed since last fetch | 24h gate blocks re-fetch; stale data returned | ETag sent; 304 + age check triggers contributions/repos re-fetch if ≥1h old |
| `/users` profile unchanged, but new commits pushed | 24h gate returns stale contributions | Row age check ensures re-fetch within 1h |
| Data changes on GitHub | Profile page stale up to 1h, city popup up to 5min, no sync | `revalidatePath` purges ISR immediately on upsert |
| `repos` count mismatch `/dev/` vs `/?user=` | Diverge due to independent cache TTLs | Consistent — both read from freshly written + revalidated DB row |
| Rate limit safety | Blunt 24h cutoff | Free 304s for unchanged profiles; expensive pipeline (GraphQL + repos) max once/hour |
| `tonystark-19` contributions | 2,317 (stale, ~2 days old) | **2,327** (live, verified locally) |

### Database migration

`supabase/migrations/036_github_etag.sql` — adds a nullable `github_etag text` column to `developers`. Populates on the next fetch per user, no backfill needed.

## Related issue

Reported by user `@tonystark-19`: contributions and stars showing data from 2 days prior.

## Checklist

- [x] `npm run lint` passes on changed file (`src/app/api/dev/[username]/route.ts` — zero errors)
- [x] Tested all 3 paths locally: 304 + fresh row (returns cached), 304 + stale row (re-fetches contributions), 200 (full fetch)
- [x] Confirmed `tonystark-19` contributions update from 2,317 → 2,327 on stale row path
- [x] No secrets or .env values committed