### PR TITLE
Refresh developer stats sooner and update search results immediately

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -193,9 +193,13 @@ export async function GET(
     };
 
     // ETag conditional request
-    const FULL_REFRESH_INTERVAL = 60 * 60 * 1000; // 1 hour
-    const cachedAge = Date.now() - new Date(cached.fetched_at).getTime();
-    const needsFullRefresh = cachedAge >= FULL_REFRESH_INTERVAL;
+    // GitHub's /users ETag does not cover repo-derived stars or GraphQL contribution totals,
+    // so only short-circuit while our cached stats are still fresh.
+    const STATS_REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+    const cachedAge = cached.fetched_at
+      ? Date.now() - new Date(cached.fetched_at).getTime()
+      : Number.POSITIVE_INFINITY;
+    const needsStatsRefresh = Number.isNaN(cachedAge) || cachedAge >= STATS_REFRESH_INTERVAL;
 
     const userRes = await fetch(
       `https://api.github.com/users/${encodeURIComponent(username)}`,
@@ -208,10 +212,10 @@ export async function GET(
       },
     );
 
-    if (userRes.status === 304 && !needsFullRefresh) {
+    if (userRes.status === 304 && !needsStatsRefresh) {
       return NextResponse.json({ ...cached, exists: true }, {
         headers: {
-          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
         },
       });
     }
@@ -384,7 +388,7 @@ export async function GET(
 
     return NextResponse.json({ ...(withRank ?? upserted), exists: true }, {
       headers: {
-        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
       },
     });
   } catch (err) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1596,37 +1596,44 @@ function HomeContent() {
         return;
       }
 
-      // If dev was recently added (e.g. just logged in) but not in local city yet,
-      // inject into local raw array and regenerate layout instantly
+      // Merge the refreshed dev back into the live city so searches update stats immediately
       let updatedBuildings: CityBuilding[] | null = null;
-      if (!existedBefore) {
-        const newDev = {
-          ...devData,
-          owned_items: [],
-          achievements: [],
-          loadout: null,
-          custom_color: null,
-          billboard_images: [],
-          active_raid_tag: null,
-          kudos_count: devData.kudos_count ?? 0,
-          visit_count: devData.visit_count ?? 0,
-          app_streak: devData.app_streak ?? 0,
-          raid_xp: devData.raid_xp ?? 0,
-          rabbit_completed: false,
-          xp_total: devData.xp_total ?? 0,
-          xp_level: devData.xp_level ?? 1,
-        };
-        rawDevsRef.current = [...rawDevsRef.current, newDev];
-        const layout = generateCityLayout(rawDevsRef.current);
-        setBuildings(layout.buildings);
-        setPlazas(layout.plazas);
-        setDecorations(layout.decorations);
-        setRiver(layout.river);
-        setBridges(layout.bridges);
-        setDistrictZones(layout.districtZones);
-        setCityCache({ ...layout, stats: stats ?? { total_developers: 0, total_contributions: 0 }, rawDevs: rawDevsRef.current });
-        updatedBuildings = layout.buildings;
-      }
+      const refreshedLogin = (devData.github_login ?? trimmed).toLowerCase();
+      const existingDev = rawDevsRef.current.find(
+        (d: Record<string, unknown>) => (d.github_login as string)?.toLowerCase() === refreshedLogin
+      );
+      const syncedDev = {
+        ...(existingDev ?? {}),
+        ...devData,
+        owned_items: (existingDev?.owned_items as string[] | undefined) ?? [],
+        achievements: (existingDev?.achievements as string[] | undefined) ?? [],
+        loadout: existingDev?.loadout ?? null,
+        custom_color: (existingDev?.custom_color as string | null | undefined) ?? null,
+        billboard_images: (existingDev?.billboard_images as string[] | undefined) ?? [],
+        active_raid_tag: existingDev?.active_raid_tag ?? null,
+        kudos_count: devData.kudos_count ?? existingDev?.kudos_count ?? 0,
+        visit_count: devData.visit_count ?? existingDev?.visit_count ?? 0,
+        app_streak: devData.app_streak ?? existingDev?.app_streak ?? 0,
+        raid_xp: devData.raid_xp ?? existingDev?.raid_xp ?? 0,
+        rabbit_completed: devData.rabbit_completed ?? existingDev?.rabbit_completed ?? false,
+        xp_total: devData.xp_total ?? existingDev?.xp_total ?? 0,
+        xp_level: devData.xp_level ?? existingDev?.xp_level ?? 1,
+      };
+      rawDevsRef.current = existedBefore
+        ? rawDevsRef.current.map((d: Record<string, unknown>) =>
+            (d.github_login as string)?.toLowerCase() === refreshedLogin ? syncedDev : d
+          )
+        : [...rawDevsRef.current, syncedDev];
+
+      const layout = generateCityLayout(rawDevsRef.current);
+      setBuildings(layout.buildings);
+      setPlazas(layout.plazas);
+      setDecorations(layout.decorations);
+      setRiver(layout.river);
+      setBridges(layout.bridges);
+      setDistrictZones(layout.districtZones);
+      setCityCache({ ...layout, stats: stats ?? { total_developers: 0, total_contributions: 0 }, rawDevs: rawDevsRef.current });
+      updatedBuildings = layout.buildings;
 
       // Focus camera on the searched building
       setFocusedBuilding(devData.github_login);
@@ -1645,7 +1652,7 @@ function HomeContent() {
       // Find the building in the current or updated city
       const searchPool = updatedBuildings ?? buildings;
       const foundBuilding = searchPool.find(
-        (b: CityBuilding) => b.login.toLowerCase() === trimmed
+        (b: CityBuilding) => b.login.toLowerCase() === refreshedLogin
       );
 
       // Compare pick mode: use snapshot so ESC mid-search doesn't cause stale state


### PR DESCRIPTION
## What does this PR do?

This fixes the delayed stat refresh behind issues like #46 / #38.

Two things were happening:

1. `/api/dev/[username]` treated the GitHub `/users/{login}` ETag as authoritative for **all** stats, but that ETag does not cover repo-derived star totals or GraphQL contribution counts.
2. When an existing developer was searched on the city page, the API could refresh the DB record, but the client kept showing the stale in-memory building data until a full reload.

This PR:

- refreshes developer stats every 5 minutes instead of waiting up to 1 hour behind the user-profile ETag short-circuit
- reduces the route cache TTL so fresh stats reach the client sooner
- merges the refreshed developer record back into the live city state so an existing building updates immediately after search

## Related issue

Fixes #46  
Addresses #38

## Screenshots

N/A (behavioral/data freshness fix)

## Checklist

- [ ] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed

### Local notes

- `git diff --check` passes
- targeted `npx eslint 'src/app/api/dev/[username]/route.ts' --max-warnings=0` passes
- `npm run build` compiled + typechecked, but local prerender later failed because Supabase env vars were not set on this machine (`supabaseUrl is required`)
