### PR TITLE
feat(admin): make admin access configurable via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,16 @@
 NEXT_PUBLIC_BASE_URL=http://localhost:3001
 
 # Supabase
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Find these in Supabase: Project Settings -> API
+NEXT_PUBLIC_SUPABASE_URL=https://domain.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Comma-separated GitHub usernames that may access /admin/ads
+ADMIN_GITHUB_LOGINS=your-github-login
 
 # GitHub (personal access token for API calls)
+# Create one in GitHub: Settings -> Developer settings -> Personal access tokens
 GITHUB_TOKEN=ghp_your-github-token
 
 # Stripe (optional - only needed for payments)

--- a/README.md
+++ b/README.md
@@ -75,13 +75,40 @@ copy .env.example .env.local
 # Windows (PowerShell)
 Copy-Item .env.example .env.local
 
-# Fill in Supabase and Stripe keys
+# Fill in your environment variables
 
 # Run the dev server
 npm run dev
 ```
 
 Open [http://localhost:3001](http://localhost:3001) to see the city.
+
+## Environment Setup
+
+After copying `.env.example` to `.env.local`, fill in these values:
+
+- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+- `GITHUB_TOKEN`
+- `ADMIN_GITHUB_LOGINS` if you want access to `/admin/ads`
+
+### Where to find the Supabase values
+
+Open your Supabase project dashboard, then go to `Project Settings -> API`.
+
+- `NEXT_PUBLIC_SUPABASE_URL`: your project URL
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: the public anon key
+- `SUPABASE_SERVICE_ROLE_KEY`: the service role key for server-side admin access
+
+For local GitHub login to work, you also need to configure the GitHub OAuth provider in Supabase and add your local callback URL if required by your setup.
+
+### Where to find the GitHub token
+
+Open GitHub and go to `Settings -> Developer settings -> Personal access tokens`.
+
+- Fine-grained tokens are recommended if you only want to grant the minimum repository/profile access this app needs.
+- Classic tokens also work if that fits your setup better.
+
+Create a token, copy it once, and place it in `GITHUB_TOKEN` inside `.env.local`.
 
 ## License
 

--- a/src/app/admin/ads/layout.tsx
+++ b/src/app/admin/ads/layout.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 import { createServerSupabase } from "@/lib/supabase-server";
-
-const OWNER_LOGIN = "srizzon";
+import { getGithubLoginFromUser, isAdminGithubLogin } from "@/lib/admin";
 
 export default async function AdminAdsLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createServerSupabase();
@@ -9,13 +8,9 @@ export default async function AdminAdsLayout({ children }: { children: React.Rea
 
   if (!user) redirect("/");
 
-  const login = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
+  const login = getGithubLoginFromUser(user);
 
-  if (login !== OWNER_LOGIN) redirect("/");
+  if (!isAdminGithubLogin(login)) redirect("/");
 
   return <>{children}</>;
 }

--- a/src/app/api/sky-ads/analytics/route.ts
+++ b/src/app/api/sky-ads/analytics/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
-
-const OWNER_LOGIN = "srizzon";
+import { getGithubLoginFromUser, isAdminGithubLogin } from "@/lib/admin";
 
 // Historical baselines from Himetrica (tracking was lost in Supabase due to www origin bug).
 // These get added on top of live Supabase counts. Remove once Supabase data catches up.
@@ -21,12 +20,8 @@ export async function GET(request: Request) {
   if (!user) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
-  const login = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
-  if (login !== OWNER_LOGIN) {
+  const login = getGithubLoginFromUser(user);
+  if (!isAdminGithubLogin(login)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/sky-ads/manage/route.ts
+++ b/src/app/api/sky-ads/manage/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { createServerSupabase } from "@/lib/supabase-server";
 import { getSupabaseAdmin } from "@/lib/supabase";
-
-const OWNER_LOGIN = "srizzon";
+import { getGithubLoginFromUser, isAdminGithubLogin } from "@/lib/admin";
 
 function generateToken(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
@@ -16,12 +15,8 @@ async function checkAdmin() {
   const supabase = await createServerSupabase();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return null;
-  const login = (
-    user.user_metadata.user_name ??
-    user.user_metadata.preferred_username ??
-    ""
-  ).toLowerCase();
-  return login === OWNER_LOGIN ? user : null;
+  const login = getGithubLoginFromUser(user);
+  return isAdminGithubLogin(login) ? user : null;
 }
 
 // Create a new ad

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+type UserLike = {
+  user_metadata?: {
+    user_name?: string;
+    preferred_username?: string;
+  };
+} | null | undefined;
+
+export function getGithubLoginFromUser(user: UserLike): string {
+  return (
+    user?.user_metadata?.user_name ??
+    user?.user_metadata?.preferred_username ??
+    ""
+  ).toLowerCase();
+}
+
+export function getAdminGithubLogins(): string[] {
+  return (process.env.ADMIN_GITHUB_LOGINS ?? "")
+    .split(",")
+    .map((login) => login.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAdminGithubLogin(login: string): boolean {
+  return getAdminGithubLogins().includes(login.trim().toLowerCase());
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -15,7 +15,7 @@ export function getStripe(): Stripe {
     throw new Error("STRIPE_SECRET_KEY is not set");
   }
   stripeInstance = new Stripe(process.env.STRIPE_SECRET_KEY, {
-    apiVersion: "2026-01-28.clover",
+    apiVersion: "2026-02-25.clover",
   });
   return stripeInstance;
 }


### PR DESCRIPTION
- Extract GitHub login extraction logic into reusable getGithubLoginFromUser helper
- Add getAdminGithubLogins function to read comma-separated logins from ADMIN_GITHUB_LOGINS env var
- Replace hardcoded OWNER_LOGIN checks with isAdminGithubLogin function across admin routes
- Update .env.example with ADMIN_GITHUB_LOGINS configuration and improved documentation
- Add detailed setup instructions to README for Supabase, GitHub token, and admin access
- Update Stripe API version to 2026-02-25.clover
- Allows multiple admins to be configured without code changes

## What does this PR do?

This change does three concrete things:

It replaces the hardcoded single-admin check with env-based admin access via ADMIN_GITHUB_LOGINS.
It centralizes the GitHub login/admin parsing logic in a reusable helper, and keeps the admin check server-side.
It updates docs and fixes the Stripe SDK type mismatch by bumping the API version to 2026-02-25.clover.
So the practical impact is:

You can grant /admin/ads access to multiple GitHub users without touching code again.
Admin access now depends on the authenticated GitHub login being listed in ADMIN_GITHUB_LOGINS.
.env.example and README.md now explain where to get the Supabase keys and GitHub token.
The project build no longer fails on the Stripe apiVersion type error.

## Related issue

None

## Screenshots

None

## Checklist

- [x] `npm run lint` passes
- [x] Tested locally
- [x] No secrets or .env values committed
