### PR TITLE
perf(cache): add immutable cache headers for /models and /audio

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,18 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/models/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
+      {
+        source: "/audio/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
+      {
         // Apply security headers to all routes
         source: "/(.*)",
         headers: securityHeaders,


### PR DESCRIPTION
Add `Cache-Control: public, max-age=31536000, immutable` for `/models/*` and `/audio/*` in `next.config.ts`.

## Why
Vercel serves `/public` files with `max-age=0, must-revalidate` by default. `paper-plane.glb` (369KB) generates ~334MB of transfer per 12h from repeat downloads. Audio files (4-5MB each) add another ~79MB. Immutable caching eliminates ~90% of origin transfer for these assets and makes return visits load faster.