### PR TITLE
perf(heartbeat): decouple write from read, CDN-cache visitor count

### DIFF
--- a/src/app/api/cron/cleanup-sessions/route.ts
+++ b/src/app/api/cron/cleanup-sessions/route.ts
@@ -41,9 +41,18 @@ export async function GET(request: NextRequest) {
     .lt("last_heartbeat_at", idleCutoff)
     .select("id");
 
+  // Prune stale site visitors (heartbeat window is 90s)
+  const visitorCutoff = new Date(now - 90_000).toISOString();
+  const { data: prunedVisitors } = await sb
+    .from("site_visitors")
+    .delete()
+    .lt("last_seen", visitorCutoff)
+    .select("session_id");
+
   return NextResponse.json({
     ok: true,
     offlined: offlinedRows?.length ?? 0,
     idled: idledRows?.length ?? 0,
+    pruned_visitors: prunedVisitors?.length ?? 0,
   });
 }

--- a/src/app/api/online/route.ts
+++ b/src/app/api/online/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
-// POST: client heartbeat — upsert + prune + count via Postgres RPC
+// POST: client heartbeat — lightweight upsert only
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null);
   const sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
   }
 
   const sb = getSupabaseAdmin();
-  const { data: count, error } = await sb.rpc("heartbeat_visitor", {
+  const { error } = await sb.rpc("heartbeat_visitor", {
     p_session_id: sessionId,
   });
 
@@ -18,10 +18,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json({ count: count ?? 1 });
+  return NextResponse.json({ ok: true });
 }
 
-// GET: just return current count
+// GET: CDN-cached visitor count (shared across all users)
 export async function GET() {
   const sb = getSupabaseAdmin();
   const { count, error } = await sb
@@ -34,6 +34,10 @@ export async function GET() {
 
   return NextResponse.json(
     { count: count ?? 0 },
-    { headers: { "Cache-Control": "no-store" } },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=10, stale-while-revalidate=20",
+      },
+    },
   );
 }

--- a/src/lib/useLiveUsers.ts
+++ b/src/lib/useLiveUsers.ts
@@ -3,26 +3,38 @@
 import { useState, useEffect, useRef } from "react";
 
 const HEARTBEAT_INTERVAL = 30_000; // 30s
+const COUNT_INTERVAL = 10_000; // 10s (CDN-cached)
 
 export function useLiveUsers() {
   const [count, setCount] = useState(1);
   const sessionId = useRef("");
 
   useEffect(() => {
-    // Generate a stable session ID per tab
     if (!sessionId.current) {
       sessionId.current = crypto.randomUUID();
     }
 
     let cancelled = false;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let countTimer: ReturnType<typeof setInterval> | null = null;
 
+    // Fire-and-forget heartbeat (keeps session alive)
     async function heartbeat() {
       try {
-        const res = await fetch("/api/online", {
+        await fetch("/api/online", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ sessionId: sessionId.current }),
         });
+      } catch {
+        // ignore
+      }
+    }
+
+    // Fetch cached count from CDN
+    async function fetchCount() {
+      try {
+        const res = await fetch("/api/online");
         if (!res.ok) return;
         const data = await res.json();
         if (!cancelled && typeof data.count === "number") {
@@ -33,12 +45,33 @@ export function useLiveUsers() {
       }
     }
 
-    heartbeat();
-    const interval = setInterval(heartbeat, HEARTBEAT_INTERVAL);
+    function start() {
+      heartbeat();
+      fetchCount();
+      heartbeatTimer = setInterval(heartbeat, HEARTBEAT_INTERVAL);
+      countTimer = setInterval(fetchCount, COUNT_INTERVAL);
+    }
+
+    function stop() {
+      if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+      if (countTimer) { clearInterval(countTimer); countTimer = null; }
+    }
+
+    function onVisibilityChange() {
+      if (document.hidden) {
+        stop();
+      } else {
+        start();
+      }
+    }
+
+    start();
+    document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, []);
 

--- a/supabase/migrations/051_simplify_heartbeat.sql
+++ b/supabase/migrations/051_simplify_heartbeat.sql
@@ -1,0 +1,10 @@
+-- Simplify heartbeat_visitor: upsert only, no prune or count.
+-- Pruning moved to cleanup-sessions cron. Count served via cached GET endpoint.
+CREATE OR REPLACE FUNCTION heartbeat_visitor(p_session_id TEXT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO site_visitors (session_id, last_seen)
+  VALUES (p_session_id, now())
+  ON CONFLICT (session_id) DO UPDATE SET last_seen = now();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Decouple `/api/online` heartbeat write from count read:
- **POST** → simplified RPC (upsert only, no prune, no count)
- **GET** → CDN-cached visitor count (`s-maxage=10`)
- **Prune** → moved to `cleanup-sessions` cron
- **Client** → fire-and-forget heartbeat + separate cached count fetch + visibility pausing

Includes migration `051_simplify_heartbeat.sql` — run `npx supabase db push` after merging.

## Why
The `heartbeat_visitor` RPC does 3 SQL ops per call (upsert + prune + count). With ~58K calls/12h, that is ~350K SQL ops. Every tab computes its own count. After this change: RPC drops to 1 op, count is shared across all users via CDN (1 origin hit per 10s instead of per-user-per-30s), and prune moves to cron (~96/day instead of ~116K/day). ~99% fewer count+prune operations.