### PR TITLE
✨ Multiplayer fly mode

### DIFF
--- a/party/fly.ts
+++ b/party/fly.ts
@@ -1,0 +1,103 @@
+import type { Party, Connection, ConnectionContext } from "partykit/server";
+
+// ─── Types ──────────────────────────────────────────────────
+interface PilotState {
+  login: string;
+  avatar: string;
+  vehicle: string;
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+  bank: number;
+}
+
+type ClientMsg =
+  | { type: "join"; login: string; avatar: string; vehicle: string }
+  | { type: "move"; x: number; y: number; z: number; yaw: number; bank: number };
+
+type ServerMsg =
+  | { type: "sync"; pilots: (PilotState & { id: string })[] }
+  | { type: "join"; pilot: PilotState & { id: string } }
+  | { type: "move"; id: string; x: number; y: number; z: number; yaw: number; bank: number }
+  | { type: "leave"; id: string };
+
+// ─── Rate limiting ──────────────────────────────────────────
+const MOVE_INTERVAL_MS = 80;
+
+// ─── Server ─────────────────────────────────────────────────
+export default class FlyServer implements Party.Server {
+  options: Party.ServerOptions = { hibernate: true };
+
+  readonly pilots = new Map<string, PilotState>();
+  readonly lastMove = new Map<string, number>();
+
+  constructor(readonly room: Party.Room) {}
+
+  onConnect(conn: Connection, _ctx: ConnectionContext) {
+    // Send current pilots to the new connection
+    const pilots = [...this.pilots.entries()].map(([id, p]) => ({ id, ...p }));
+    const syncMsg: ServerMsg = { type: "sync", pilots };
+    conn.send(JSON.stringify(syncMsg));
+  }
+
+  onMessage(message: string, sender: Connection) {
+    let msg: ClientMsg;
+    try {
+      msg = JSON.parse(message);
+    } catch {
+      return;
+    }
+
+    const id = sender.id;
+    const now = Date.now();
+
+    if (msg.type === "join") {
+      if (typeof msg.login !== "string" || typeof msg.avatar !== "string" || typeof msg.vehicle !== "string") return;
+      const pilot: PilotState = {
+        login: msg.login.slice(0, 39),
+        avatar: msg.avatar.slice(0, 256),
+        vehicle: msg.vehicle.slice(0, 32),
+        x: 0,
+        y: 120,
+        z: 400,
+        yaw: 0,
+        bank: 0,
+      };
+      this.pilots.set(id, pilot);
+      const joinMsg: ServerMsg = { type: "join", pilot: { id, ...pilot } };
+      this.room.broadcast(JSON.stringify(joinMsg), [sender.id]);
+    }
+
+    if (msg.type === "move") {
+      const last = this.lastMove.get(id) ?? 0;
+      if (now - last < MOVE_INTERVAL_MS) return;
+      this.lastMove.set(id, now);
+
+      const pilot = this.pilots.get(id);
+      if (!pilot) return;
+
+      if (typeof msg.x !== "number" || typeof msg.y !== "number" || typeof msg.z !== "number") return;
+      if (typeof msg.yaw !== "number" || typeof msg.bank !== "number") return;
+
+      pilot.x = msg.x;
+      pilot.y = msg.y;
+      pilot.z = msg.z;
+      pilot.yaw = msg.yaw;
+      pilot.bank = msg.bank;
+
+      const moveMsg: ServerMsg = { type: "move", id, x: msg.x, y: msg.y, z: msg.z, yaw: msg.yaw, bank: msg.bank };
+      this.room.broadcast(JSON.stringify(moveMsg), [sender.id]);
+    }
+  }
+
+  onClose(conn: Connection) {
+    const id = conn.id;
+    this.pilots.delete(id);
+    this.lastMove.delete(id);
+    const leaveMsg: ServerMsg = { type: "leave", id };
+    this.room.broadcast(JSON.stringify(leaveMsg));
+  }
+}
+
+FlyServer satisfies Party.Worker;

--- a/partykit.json
+++ b/partykit.json
@@ -2,7 +2,8 @@
   "name": "git-city-arcade",
   "main": "party/arcade.ts",
   "parties": {
-    "lobby": "party/lobby.ts"
+    "lobby": "party/lobby.ts",
+    "fly": "party/fly.ts"
   },
   "compatibilityDate": "2025-06-01"
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ import { ITEM_NAMES, ITEM_EMOJIS } from "@/lib/zones";
 import { useStreakCheckin } from "@/lib/useStreakCheckin";
 import { useLiveUsers } from "@/lib/useLiveUsers";
 import { useCodingPresence } from "@/lib/useCodingPresence";
+import { useFlyPresence } from "@/lib/useFlyPresence";
 import { useRaidSequence } from "@/lib/useRaidSequence";
 import { isFridayThe13th } from "@/lib/raid";
 import { useDailies } from "@/lib/useDailies";
@@ -704,6 +705,14 @@ function HomeContent() {
     session?.user?.user_metadata?.preferred_username ??
     ""
   ).toLowerCase();
+
+  const authAvatar = (session?.user?.user_metadata?.avatar_url ?? "") as string;
+  const { pilotsRef: flyPilotsRef, sendMove: flySendMove } = useFlyPresence(
+    flyMode,
+    authLogin,
+    authAvatar,
+    flyVehicle,
+  );
 
   // Fetch existing VS Code API key
   useEffect(() => {
@@ -2391,6 +2400,8 @@ function HomeContent() {
             setExploreMode(true);
           }
         }}
+        onFlyMove={flySendMove}
+        flyPilotsRef={flyPilotsRef}
       />
 
       {/* Loading screen overlay */}

--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -28,6 +28,8 @@ import CompareSplitScreen from "./CompareSplitScreen";
 import LocalizedFireworks from "./LocalizedFireworks";
 import WallpaperParallax from "./WallpaperParallax";
 import ThemeSkyFX from "./ThemeSkyFX";
+import RemotePilots from "./RemotePilots";
+import type { RemotePilot } from "@/lib/useFlyPresence";
 
 // ─── Theme Definitions ───────────────────────────────────────
 
@@ -602,7 +604,7 @@ const _idealLook = new THREE.Vector3();
 const _blendedPos = new THREE.Vector3();
 const _yAxis = new THREE.Vector3(0, 1, 0);
 
-function AirplaneFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = false, startPaused = false, vehicleType = "airplane", posRef, cityRadius = 3500, isMobile = false, onJoystickState, boostActive = false, brakeActive = false }: { onExit: () => void; onHud: (s: number, a: number, x: number, z: number, yaw: number) => void; onPause: (paused: boolean) => void; pauseSignal?: number; hasOverlay?: boolean; startPaused?: boolean; vehicleType?: string; posRef?: React.MutableRefObject<THREE.Vector3>; cityRadius?: number; isMobile?: boolean; onJoystickState?: (state: { baseX: number; baseY: number; dx: number; dy: number } | null) => void; boostActive?: boolean; brakeActive?: boolean }) {
+function AirplaneFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = false, startPaused = false, vehicleType = "airplane", posRef, cityRadius = 3500, isMobile = false, onJoystickState, boostActive = false, brakeActive = false, onFlyMove }: { onExit: () => void; onHud: (s: number, a: number, x: number, z: number, yaw: number) => void; onPause: (paused: boolean) => void; pauseSignal?: number; hasOverlay?: boolean; startPaused?: boolean; vehicleType?: string; posRef?: React.MutableRefObject<THREE.Vector3>; cityRadius?: number; isMobile?: boolean; onJoystickState?: (state: { baseX: number; baseY: number; dx: number; dy: number } | null) => void; boostActive?: boolean; brakeActive?: boolean; onFlyMove?: (x: number, y: number, z: number, yaw: number, bank: number) => void }) {
   const { camera } = useThree();
   const ref = useRef<THREE.Group>(null);
   const orbitRef = useRef<any>(null);
@@ -956,6 +958,9 @@ function AirplaneFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = 
     }
 
     if (posRef) posRef.current.copy(pos.current);
+
+    // Broadcast position to multiplayer presence (throttled internally)
+    onFlyMove?.(pos.current.x, pos.current.y, pos.current.z, yaw.current, bank.current);
 
     const targetBank = -turnInput * MAX_BANK;
     bank.current += (targetBank - bank.current) * 5 * dt;
@@ -2125,6 +2130,8 @@ interface Props {
   liveByLogin?: Map<string, LiveSession>;
   cityEnergy?: number;
   onCompareCinematicEnd?: () => void;
+  onFlyMove?: (x: number, y: number, z: number, yaw: number, bank: number) => void;
+  flyPilotsRef?: React.MutableRefObject<Map<string, RemotePilot>>;
 }
 
 // Dynamically adjust scene exposure based on city energy (devs coding)
@@ -2147,7 +2154,7 @@ function CityExposure({ cityEnergy }: { cityEnergy: number }) {
 // Plaza indices for rabbit sightings (progressively further from center)
 const RABBIT_PLAZA_INDICES = [1, 2, 4, 7, 10]; // plazas[1]=slot3, [2]=slot7, [4]=slot18, [7]=slot42, [10]=slot75
 
-export default function CityCanvas({ buildings, plazas, decorations, river, bridges, flyMode, flyVehicle, onExitFly, onCollect, themeIndex, onHud, onPause, focusedBuilding, focusedBuildingB, accentColor, onClearFocus, onBuildingClick, onFocusInfo, flyPauseSignal, flyHasOverlay, flyStartPaused, isMobile, onJoystickState, flyBoostActive, flyBrakeActive, skyAds, onAdClick, onAdViewed, introMode, onIntroEnd, raidPhase, raidData, raidAttacker, raidDefender, onRaidPhaseComplete, onLandmarkClick, onEArcadeClick, onSponsorClick, sponsorFocusPos, activeSponsorSlug, rabbitSighting, onRabbitCaught, rabbitCinematic, onRabbitCinematicEnd, rabbitCinematicTarget, ghostPreviewLogin, holdRise, celebrationActive, wallpaperMode, wallpaperSpeed, liveByLogin, cityEnergy, onCompareCinematicEnd }: Props) {
+export default function CityCanvas({ buildings, plazas, decorations, river, bridges, flyMode, flyVehicle, onExitFly, onCollect, themeIndex, onHud, onPause, focusedBuilding, focusedBuildingB, accentColor, onClearFocus, onBuildingClick, onFocusInfo, flyPauseSignal, flyHasOverlay, flyStartPaused, isMobile, onJoystickState, flyBoostActive, flyBrakeActive, skyAds, onAdClick, onAdViewed, introMode, onIntroEnd, raidPhase, raidData, raidAttacker, raidDefender, onRaidPhaseComplete, onLandmarkClick, onEArcadeClick, onSponsorClick, sponsorFocusPos, activeSponsorSlug, rabbitSighting, onRabbitCaught, rabbitCinematic, onRabbitCinematicEnd, rabbitCinematicTarget, ghostPreviewLogin, holdRise, celebrationActive, wallpaperMode, wallpaperSpeed, liveByLogin, cityEnergy, onCompareCinematicEnd, onFlyMove, flyPilotsRef }: Props) {
   const [isCompareCinematicPlaying, setIsCompareCinematicPlaying] = useState(false);
   const prevComparePairRef = useRef<string>("");
 
@@ -2277,8 +2284,9 @@ export default function CityCanvas({ buildings, plazas, decorations, river, brid
 
           {!introMode && flyMode && (
             <>
-              <AirplaneFlight onExit={onExitFly} onHud={onHud ?? (() => { })} onPause={onPause ?? (() => { })} pauseSignal={flyPauseSignal} hasOverlay={flyHasOverlay} startPaused={flyStartPaused} vehicleType={flyVehicle} posRef={flyPosRef} cityRadius={cityRadius} isMobile={isMobile} onJoystickState={onJoystickState} boostActive={flyBoostActive} brakeActive={flyBrakeActive} />
+              <AirplaneFlight onExit={onExitFly} onHud={onHud ?? (() => { })} onPause={onPause ?? (() => { })} pauseSignal={flyPauseSignal} hasOverlay={flyHasOverlay} startPaused={flyStartPaused} vehicleType={flyVehicle} posRef={flyPosRef} cityRadius={cityRadius} isMobile={isMobile} onJoystickState={onJoystickState} boostActive={flyBoostActive} brakeActive={flyBrakeActive} onFlyMove={onFlyMove} />
               <SkyCollectibles playerPosRef={flyPosRef} accentColor={accentColor ?? "#6090e0"} onCollect={onCollect ?? (() => { })} cityRadius={cityRadius} />
+              {flyPilotsRef && <RemotePilots pilotsRef={flyPilotsRef} />}
             </>
           )}
         </>

--- a/src/components/RemotePilots.tsx
+++ b/src/components/RemotePilots.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import type { RemotePilot } from "@/lib/useFlyPresence";
+
+// ─── Constants ──────────────────────────────────────────────
+const LERP_DURATION = 0.12;
+
+// Shared geometry / materials (created once, reused across all pilots)
+let sharedBodyGeo: THREE.BoxGeometry | null = null;
+let sharedWingGeo: THREE.BoxGeometry | null = null;
+let sharedTailGeo: THREE.BoxGeometry | null = null;
+let sharedBodyMat: THREE.MeshStandardMaterial | null = null;
+let sharedWingMat: THREE.MeshStandardMaterial | null = null;
+
+function getSharedGeo() {
+  if (!sharedBodyGeo) {
+    sharedBodyGeo = new THREE.BoxGeometry(2, 0.6, 3);
+    sharedWingGeo = new THREE.BoxGeometry(6, 0.15, 1.2);
+    sharedTailGeo = new THREE.BoxGeometry(2, 1, 0.3);
+    sharedBodyMat = new THREE.MeshStandardMaterial({ color: "#6090e0" });
+    sharedWingMat = new THREE.MeshStandardMaterial({ color: "#4070c0" });
+  }
+  return { sharedBodyGeo: sharedBodyGeo!, sharedWingGeo: sharedWingGeo!, sharedTailGeo: sharedTailGeo!, sharedBodyMat: sharedBodyMat!, sharedWingMat: sharedWingMat! };
+}
+
+interface PilotEntry {
+  container: THREE.Group;
+  labelMap: THREE.CanvasTexture;
+}
+
+// ─── Main component (imperative for zero re-renders) ────────
+
+export default function RemotePilots({
+  pilotsRef,
+}: {
+  pilotsRef: React.MutableRefObject<Map<string, RemotePilot>>;
+}) {
+  const wrapperRef = useRef<THREE.Group>(null);
+  const meshes = useRef<Map<string, PilotEntry>>(new Map());
+
+  useFrame((_, delta) => {
+    if (!wrapperRef.current) return;
+    const pilots = pilotsRef.current;
+
+    // Remove disconnected pilots
+    for (const [id, entry] of meshes.current) {
+      if (!pilots.has(id)) {
+        wrapperRef.current.remove(entry.container);
+        entry.labelMap.dispose();
+        meshes.current.delete(id);
+      }
+    }
+
+    // Add new / update existing
+    for (const [id, pilot] of pilots) {
+      let entry = meshes.current.get(id);
+
+      if (!entry) {
+        const { sharedBodyGeo: bg, sharedWingGeo: wg, sharedTailGeo: tg, sharedBodyMat: bm, sharedWingMat: wm } = getSharedGeo();
+
+        // Container: holds position + rotation
+        const container = new THREE.Group();
+
+        // Scaled mesh sub-group (matches AirplaneFlight scale=4)
+        const meshGroup = new THREE.Group();
+        meshGroup.scale.set(4, 4, 4);
+
+        const body = new THREE.Mesh(bg, bm);
+        meshGroup.add(body);
+
+        const wing = new THREE.Mesh(wg, wm);
+        wing.position.set(0, 0.1, 0.3);
+        meshGroup.add(wing);
+
+        const tail = new THREE.Mesh(tg, wm);
+        tail.position.set(0, 0.5, 1.4);
+        meshGroup.add(tail);
+
+        container.add(meshGroup);
+
+        // Point light
+        const light = new THREE.PointLight("#f0c870", 10, 40);
+        light.position.set(0, -2, 0);
+        container.add(light);
+
+        // Username label sprite
+        const canvas = document.createElement("canvas");
+        canvas.width = 256;
+        canvas.height = 64;
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          ctx.fillStyle = "rgba(0,0,0,0.6)";
+          ctx.beginPath();
+          ctx.roundRect(4, 4, 248, 56, 8);
+          ctx.fill();
+          ctx.fillStyle = "#ffffff";
+          ctx.font = "bold 28px monospace";
+          ctx.textAlign = "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText(pilot.login.slice(0, 16), 128, 32);
+        }
+        const labelMap = new THREE.CanvasTexture(canvas);
+        const labelMat = new THREE.SpriteMaterial({ map: labelMap, transparent: true, depthTest: false });
+        const label = new THREE.Sprite(labelMat);
+        label.position.set(0, -12, 0);
+        label.scale.set(20, 5, 1);
+        container.add(label);
+
+        wrapperRef.current.add(container);
+        entry = { container, labelMap };
+        meshes.current.set(id, entry);
+      }
+
+      // Advance lerp
+      pilot.lerpTimer = Math.min(1, pilot.lerpTimer + delta / LERP_DURATION);
+      const t = pilot.lerpTimer;
+
+      const ix = pilot.prevX + (pilot.x - pilot.prevX) * t;
+      const iy = pilot.prevY + (pilot.y - pilot.prevY) * t;
+      const iz = pilot.prevZ + (pilot.z - pilot.prevZ) * t;
+      const iyaw = lerpAngle(pilot.prevYaw, pilot.yaw, t);
+      const ibank = lerpAngle(pilot.prevBank, pilot.bank, t);
+
+      entry.container.position.set(ix, iy, iz);
+      entry.container.rotation.set(0, iyaw, ibank, "YXZ");
+    }
+  });
+
+  return <group ref={wrapperRef} />;
+}
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function lerpAngle(a: number, b: number, t: number): number {
+  let diff = b - a;
+  while (diff > Math.PI) diff -= Math.PI * 2;
+  while (diff < -Math.PI) diff += Math.PI * 2;
+  return a + diff * t;
+}

--- a/src/components/RemotePilots.tsx
+++ b/src/components/RemotePilots.tsx
@@ -1,135 +1,99 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
+import { VehicleMesh } from "./RaidSequence3D";
 import type { RemotePilot } from "@/lib/useFlyPresence";
 
 // ─── Constants ──────────────────────────────────────────────
 const LERP_DURATION = 0.12;
 
-// Shared geometry / materials (created once, reused across all pilots)
-let sharedBodyGeo: THREE.BoxGeometry | null = null;
-let sharedWingGeo: THREE.BoxGeometry | null = null;
-let sharedTailGeo: THREE.BoxGeometry | null = null;
-let sharedBodyMat: THREE.MeshStandardMaterial | null = null;
-let sharedWingMat: THREE.MeshStandardMaterial | null = null;
+// ─── Single remote pilot ────────────────────────────────────
 
-function getSharedGeo() {
-  if (!sharedBodyGeo) {
-    sharedBodyGeo = new THREE.BoxGeometry(2, 0.6, 3);
-    sharedWingGeo = new THREE.BoxGeometry(6, 0.15, 1.2);
-    sharedTailGeo = new THREE.BoxGeometry(2, 1, 0.3);
-    sharedBodyMat = new THREE.MeshStandardMaterial({ color: "#6090e0" });
-    sharedWingMat = new THREE.MeshStandardMaterial({ color: "#4070c0" });
-  }
-  return { sharedBodyGeo: sharedBodyGeo!, sharedWingGeo: sharedWingGeo!, sharedTailGeo: sharedTailGeo!, sharedBodyMat: sharedBodyMat!, sharedWingMat: sharedWingMat! };
+function RemotePilotMesh({ pilot }: { pilot: RemotePilot }) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  const labelSprite = useMemo(() => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 256;
+    canvas.height = 64;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "rgba(0,0,0,0.6)";
+      ctx.beginPath();
+      ctx.roundRect(4, 4, 248, 56, 8);
+      ctx.fill();
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 28px monospace";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(pilot.login.slice(0, 16), 128, 32);
+    }
+    const tex = new THREE.CanvasTexture(canvas);
+    return tex;
+  }, [pilot.login]);
+
+  useFrame((_, delta) => {
+    if (!groupRef.current) return;
+
+    pilot.lerpTimer = Math.min(1, pilot.lerpTimer + delta / LERP_DURATION);
+    const t = pilot.lerpTimer;
+
+    const ix = pilot.prevX + (pilot.x - pilot.prevX) * t;
+    const iy = pilot.prevY + (pilot.y - pilot.prevY) * t;
+    const iz = pilot.prevZ + (pilot.z - pilot.prevZ) * t;
+    const iyaw = lerpAngle(pilot.prevYaw, pilot.yaw, t);
+    const ibank = lerpAngle(pilot.prevBank, pilot.bank, t);
+
+    groupRef.current.position.set(ix, iy, iz);
+    groupRef.current.rotation.set(0, iyaw, ibank, "YXZ");
+  });
+
+  return (
+    <group ref={groupRef}>
+      <group scale={[4, 4, 4]}>
+        <VehicleMesh type={pilot.vehicle || "airplane"} />
+      </group>
+      <pointLight position={[0, -2, 0]} color="#f0c870" intensity={15} distance={60} />
+      <pointLight position={[0, 3, -4]} color="#ffffff" intensity={5} distance={30} />
+      <sprite position={[0, -12, 0]} scale={[20, 5, 1]}>
+        <spriteMaterial map={labelSprite} transparent depthTest={false} />
+      </sprite>
+    </group>
+  );
 }
 
-interface PilotEntry {
-  container: THREE.Group;
-  labelMap: THREE.CanvasTexture;
-}
-
-// ─── Main component (imperative for zero re-renders) ────────
+// ─── Main component ─────────────────────────────────────────
 
 export default function RemotePilots({
   pilotsRef,
 }: {
   pilotsRef: React.MutableRefObject<Map<string, RemotePilot>>;
 }) {
-  const wrapperRef = useRef<THREE.Group>(null);
-  const meshes = useRef<Map<string, PilotEntry>>(new Map());
+  const [tick, setTick] = useState(0);
+  const prevKeysRef = useRef("");
 
-  useFrame((_, delta) => {
-    if (!wrapperRef.current) return;
-    const pilots = pilotsRef.current;
-
-    // Remove disconnected pilots
-    for (const [id, entry] of meshes.current) {
-      if (!pilots.has(id)) {
-        wrapperRef.current.remove(entry.container);
-        entry.labelMap.dispose();
-        meshes.current.delete(id);
-      }
-    }
-
-    // Add new / update existing
-    for (const [id, pilot] of pilots) {
-      let entry = meshes.current.get(id);
-
-      if (!entry) {
-        const { sharedBodyGeo: bg, sharedWingGeo: wg, sharedTailGeo: tg, sharedBodyMat: bm, sharedWingMat: wm } = getSharedGeo();
-
-        // Container: holds position + rotation
-        const container = new THREE.Group();
-
-        // Scaled mesh sub-group (matches AirplaneFlight scale=4)
-        const meshGroup = new THREE.Group();
-        meshGroup.scale.set(4, 4, 4);
-
-        const body = new THREE.Mesh(bg, bm);
-        meshGroup.add(body);
-
-        const wing = new THREE.Mesh(wg, wm);
-        wing.position.set(0, 0.1, 0.3);
-        meshGroup.add(wing);
-
-        const tail = new THREE.Mesh(tg, wm);
-        tail.position.set(0, 0.5, 1.4);
-        meshGroup.add(tail);
-
-        container.add(meshGroup);
-
-        // Point light
-        const light = new THREE.PointLight("#f0c870", 10, 40);
-        light.position.set(0, -2, 0);
-        container.add(light);
-
-        // Username label sprite
-        const canvas = document.createElement("canvas");
-        canvas.width = 256;
-        canvas.height = 64;
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          ctx.fillStyle = "rgba(0,0,0,0.6)";
-          ctx.beginPath();
-          ctx.roundRect(4, 4, 248, 56, 8);
-          ctx.fill();
-          ctx.fillStyle = "#ffffff";
-          ctx.font = "bold 28px monospace";
-          ctx.textAlign = "center";
-          ctx.textBaseline = "middle";
-          ctx.fillText(pilot.login.slice(0, 16), 128, 32);
-        }
-        const labelMap = new THREE.CanvasTexture(canvas);
-        const labelMat = new THREE.SpriteMaterial({ map: labelMap, transparent: true, depthTest: false });
-        const label = new THREE.Sprite(labelMat);
-        label.position.set(0, -12, 0);
-        label.scale.set(20, 5, 1);
-        container.add(label);
-
-        wrapperRef.current.add(container);
-        entry = { container, labelMap };
-        meshes.current.set(id, entry);
-      }
-
-      // Advance lerp
-      pilot.lerpTimer = Math.min(1, pilot.lerpTimer + delta / LERP_DURATION);
-      const t = pilot.lerpTimer;
-
-      const ix = pilot.prevX + (pilot.x - pilot.prevX) * t;
-      const iy = pilot.prevY + (pilot.y - pilot.prevY) * t;
-      const iz = pilot.prevZ + (pilot.z - pilot.prevZ) * t;
-      const iyaw = lerpAngle(pilot.prevYaw, pilot.yaw, t);
-      const ibank = lerpAngle(pilot.prevBank, pilot.bank, t);
-
-      entry.container.position.set(ix, iy, iz);
-      entry.container.rotation.set(0, iyaw, ibank, "YXZ");
+  useFrame(() => {
+    const keys = Array.from(pilotsRef.current.keys()).join(",");
+    if (keys !== prevKeysRef.current) {
+      prevKeysRef.current = keys;
+      setTick((t) => t + 1);
     }
   });
 
-  return <group ref={wrapperRef} />;
+  // tick used to trigger re-render when pilot list changes
+  void tick;
+
+  const pilots = Array.from(pilotsRef.current.entries());
+
+  return (
+    <group>
+      {pilots.map(([id, pilot]) => (
+        <RemotePilotMesh key={id} pilot={pilot} />
+      ))}
+    </group>
+  );
 }
 
 // ─── Helpers ────────────────────────────────────────────────

--- a/src/lib/useFlyPresence.ts
+++ b/src/lib/useFlyPresence.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import PartySocket from "partysocket";
+
+// ─── Types ──────────────────────────────────────────────────
+
+export interface RemotePilot {
+  login: string;
+  avatar: string;
+  vehicle: string;
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+  bank: number;
+  prevX: number;
+  prevY: number;
+  prevZ: number;
+  prevYaw: number;
+  prevBank: number;
+  lerpTimer: number;
+}
+
+type ServerMsg =
+  | { type: "sync"; pilots: { id: string; login: string; avatar: string; vehicle: string; x: number; y: number; z: number; yaw: number; bank: number }[] }
+  | { type: "join"; pilot: { id: string; login: string; avatar: string; vehicle: string; x: number; y: number; z: number; yaw: number; bank: number } }
+  | { type: "move"; id: string; x: number; y: number; z: number; yaw: number; bank: number }
+  | { type: "leave"; id: string };
+
+// ─── Throttle interval ──────────────────────────────────────
+const SEND_INTERVAL_MS = 100;
+
+// ─── Hook ───────────────────────────────────────────────────
+
+export function useFlyPresence(
+  active: boolean,
+  login: string,
+  avatar: string,
+  vehicle: string,
+): {
+  pilotsRef: React.MutableRefObject<Map<string, RemotePilot>>;
+  sendMove: (x: number, y: number, z: number, yaw: number, bank: number) => void;
+} {
+  const pilotsRef = useRef<Map<string, RemotePilot>>(new Map());
+  const socketRef = useRef<PartySocket | null>(null);
+  const lastSendRef = useRef(0);
+
+  useEffect(() => {
+    if (!active || !login) {
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+      pilotsRef.current.clear();
+      return;
+    }
+
+    const host = process.env.NEXT_PUBLIC_PARTYKIT_HOST ?? "localhost:1999";
+
+    const ws = new PartySocket({
+      host,
+      party: "fly",
+      room: "city",
+    });
+    socketRef.current = ws;
+
+    ws.addEventListener("open", () => {
+      ws.send(JSON.stringify({ type: "join", login, avatar, vehicle }));
+    });
+
+    ws.addEventListener("message", (evt) => {
+      let msg: ServerMsg;
+      try {
+        msg = JSON.parse(evt.data);
+      } catch {
+        return;
+      }
+
+      if (msg.type === "sync") {
+        for (const p of msg.pilots) {
+          pilotsRef.current.set(p.id, {
+            login: p.login, avatar: p.avatar, vehicle: p.vehicle,
+            x: p.x, y: p.y, z: p.z, yaw: p.yaw, bank: p.bank,
+            prevX: p.x, prevY: p.y, prevZ: p.z, prevYaw: p.yaw, prevBank: p.bank,
+            lerpTimer: 1,
+          });
+        }
+      }
+
+      if (msg.type === "join") {
+        const p = msg.pilot;
+        pilotsRef.current.set(p.id, {
+          login: p.login, avatar: p.avatar, vehicle: p.vehicle,
+          x: p.x, y: p.y, z: p.z, yaw: p.yaw, bank: p.bank,
+          prevX: p.x, prevY: p.y, prevZ: p.z, prevYaw: p.yaw, prevBank: p.bank,
+          lerpTimer: 1,
+        });
+      }
+
+      if (msg.type === "move") {
+        const pilot = pilotsRef.current.get(msg.id);
+        if (pilot) {
+          pilot.prevX = pilot.x;
+          pilot.prevY = pilot.y;
+          pilot.prevZ = pilot.z;
+          pilot.prevYaw = pilot.yaw;
+          pilot.prevBank = pilot.bank;
+          pilot.x = msg.x;
+          pilot.y = msg.y;
+          pilot.z = msg.z;
+          pilot.yaw = msg.yaw;
+          pilot.bank = msg.bank;
+          pilot.lerpTimer = 0;
+        }
+      }
+
+      if (msg.type === "leave") {
+        pilotsRef.current.delete(msg.id);
+      }
+    });
+
+    return () => {
+      ws.close();
+      socketRef.current = null;
+      pilotsRef.current.clear();
+    };
+  }, [active, login, avatar, vehicle]);
+
+  const sendMove = useCallback((x: number, y: number, z: number, yaw: number, bank: number) => {
+    const now = Date.now();
+    if (now - lastSendRef.current < SEND_INTERVAL_MS) return;
+    lastSendRef.current = now;
+    socketRef.current?.send(JSON.stringify({ type: "move", x, y, z, yaw, bank }));
+  }, []);
+
+  return { pilotsRef, sendMove };
+}


### PR DESCRIPTION
## Summary
- New PartyKit server (`party/fly.ts`) relays pilot positions with 80ms rate limiting
- `useFlyPresence` hook connects/disconnects automatically when entering/exiting fly mode
- `RemotePilots` Three.js component renders other players' airplanes with lerp interpolation at 60fps
- Zero React re-renders — all state in refs, fully imperative Three.js rendering

## How it works
1. Player enters fly mode → connects to PartyKit `fly` party
2. Sends position (x, y, z, yaw, bank) every ~100ms
3. Server broadcasts to all other connected pilots
4. Remote airplanes rendered with smooth interpolation + username labels

## Files
- `party/fly.ts` — PartyKit server (~105 lines)
- `src/lib/useFlyPresence.ts` — presence hook (~130 lines)
- `src/components/RemotePilots.tsx` — 3D rendering (~135 lines)
- `partykit.json` — added `fly` party
- `src/components/CityCanvas.tsx` — wired in RemotePilots + onFlyMove
- `src/app/page.tsx` — connected useFlyPresence hook

## Test plan
- [ ] Open 2 browser tabs, enter fly mode in both
- [ ] Verify you see the other player's airplane flying
- [ ] Verify username labels appear below remote planes
- [ ] Verify smooth interpolation (no teleporting)
- [ ] Verify cleanup when exiting fly mode (plane disappears)
- [ ] Deploy PartyKit with `npx partykit deploy` before testing on Vercel preview