### PR TITLE
🐛 fix(effects): stabilize LOD effect culling

### DIFF
--- a/src/components/EffectsLayer.tsx
+++ b/src/components/EffectsLayer.tsx
@@ -214,11 +214,21 @@ export default function EffectsLayer({
 
     // Cap at maxActiveEffects — keep closest buildings
     if (newSet.size > maxActiveEffects) {
+      const hysteresisBiasSq = Math.max(0, farSq - nearSq);
+      
       const withDist = Array.from(newSet).map((idx) => {
         const b = buildings[idx];
         const dx = cx - b.position[0];
         const dz = cz - b.position[2];
-        return { idx, distSq: dx * dx + dz * dz };
+        const actualDistSq = dx * dx + dz * dz;
+        
+        // Bias active buildings to reduce LOD churn near the cutoff boundary
+        const isActive = activeSetRef.current.has(idx);
+        const prioritizedDistSq = isActive 
+          ? Math.max(0, actualDistSq - hysteresisBiasSq) 
+          : actualDistSq;
+          
+        return { idx, distSq: prioritizedDistSq };
       });
       withDist.sort((a, b) => a.distSq - b.distSq);
       newSet.clear();


### PR DESCRIPTION
## What does this PR do?

Fixes visual popping of high-detail building effects during fly mode in dense city areas.

`EffectsLayer.tsx` already applied hysteresis for distance-based activation, but the `maxActiveEffects` capacity limit introduced a second instability source. Buildings near the active-set cutoff boundary continuously swapped positions during small camera movements, triggering rapid mount/unmount churn for `ActiveBuildingEffects`.

This change stabilizes the capacity-culling step by applying a small prioritization bias to already-active buildings:

```ts
const prioritizedDistSq = isActive
  ? Math.max(0,actualDistSq - hysteresisBiasSq)
  : actualDistSq;
```

This makes active effects slightly "stickier" so they remain mounted until meaningfully outdistanced by new candidates, reducing visible popping while preserving the existing rendering architecture and performance characteristics.

## Related issue

Fixes #92

## Screenshots

N/A (visual stabilization / reduced effect churn)

## Checklist

* [x] Tested locally
* [x] No secrets or `.env` values committed
* [ ] `npm run lint` passes globally (repo currently contains unrelated pre-existing lint errors)
