### PR TITLE
docs: explain city rank

### DIFF
--- a/src/app/api/cron/monthly-digest/route.ts
+++ b/src/app/api/cron/monthly-digest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { sendNotificationAsync } from "@/lib/notifications";
 import { buildButton, buildStatsTable } from "@/lib/email-template";
+import { CITY_RANK_EMAIL_LABEL, CITY_RANK_SHORT_DESCRIPTION } from "@/lib/city-rank";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://thegitcity.com";
 
@@ -93,7 +94,7 @@ export async function GET(request: NextRequest) {
           { label: "Current streak", value: `${dev.app_streak ?? 0} days` },
         ];
 
-        if (dev.rank) stats.push({ label: "City rank", value: `#${dev.rank}` });
+        if (dev.rank) stats.push({ label: CITY_RANK_EMAIL_LABEL, value: `#${dev.rank}` });
         if (achievements > 0) stats.push({ label: "Achievements unlocked", value: achievements });
         if (raids) {
           stats.push({ label: "Battles launched", value: raids.attacks });
@@ -106,7 +107,7 @@ export async function GET(request: NextRequest) {
           developerId: dev.id,
           dedupKey: `monthly_digest:${dev.id}:${yearMonth}`,
           title: `Your ${monthName} in Git City`,
-          body: `${monthName} recap: ${dev.contributions.toLocaleString()} total contributions, rank #${dev.rank ?? "?"}.`,
+          body: `${monthName} recap: ${dev.contributions.toLocaleString()} total contributions, rank #${dev.rank ?? "?"}. ${CITY_RANK_SHORT_DESCRIPTION}`,
           html: `
             <p style="color: #c8e64a; font-size: 16px;">Your ${monthName} in Git City</p>
             ${buildStatsTable(stats)}

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 import { sendNotificationAsync } from "@/lib/notifications";
 import { buildButton, buildStatsTable } from "@/lib/email-template";
+import { CITY_RANK_EMAIL_LABEL, CITY_RANK_SHORT_DESCRIPTION } from "@/lib/city-rank";
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://thegitcity.com";
 
@@ -105,7 +106,7 @@ export async function GET(request: NextRequest) {
           stats.push({ label: "Achievements", value: weeklyAchievements });
         }
         if (dev.rank) {
-          stats.push({ label: "City rank", value: `#${dev.rank}` });
+          stats.push({ label: CITY_RANK_EMAIL_LABEL, value: `#${dev.rank}` });
         }
 
         sendNotificationAsync({
@@ -114,7 +115,7 @@ export async function GET(request: NextRequest) {
           developerId: dev.id,
           dedupKey: `weekly_digest:${dev.id}:${weekStartDate}`,
           title: `Your week in Git City: ${dev.app_streak ?? 0}-day streak, rank #${dev.rank ?? "?"}`,
-          body: `Streak: ${dev.app_streak ?? 0} days. Kudos: ${weeklyKudos}. Check your weekly recap.`,
+          body: `Streak: ${dev.app_streak ?? 0} days. Kudos: ${weeklyKudos}. ${CITY_RANK_SHORT_DESCRIPTION} Check your weekly recap.`,
           html: `
             <p style="color: #c8e64a; font-size: 16px;">Your week in Git City</p>
             ${buildStatsTable(stats)}

--- a/src/app/dev/[username]/page.tsx
+++ b/src/app/dev/[username]/page.tsx
@@ -10,6 +10,7 @@ import { TIER_COLORS } from "@/lib/achievements";
 import { inferDistrict } from "@/lib/github";
 import { ITEM_NAMES } from "@/lib/zones";
 import { rankFromLevel, tierFromLevel, levelProgress, xpForLevel } from "@/lib/xp";
+import { CITY_RANK_DESCRIPTION } from "@/lib/city-rank";
 import ClaimButton from "@/components/ClaimButton";
 import DeleteAccountButton from "@/components/DeleteAccountButton";
 import ShareButtons from "@/components/ShareButtons";
@@ -200,9 +201,19 @@ export default async function DevPage({ params }: Props) {
 
               {/* Rank Badge */}
               {dev.rank && (
-                <div className="mt-3 inline-block border-2 px-3 py-1 text-sm" style={{ borderColor: accent, color: accent }}>
-                  #{dev.rank} in the city
-                </div>
+                <>
+                  <div
+                    className="mt-3 inline-block border-2 px-3 py-1 text-sm"
+                    style={{ borderColor: accent, color: accent }}
+                    title={CITY_RANK_DESCRIPTION}
+                    aria-label={`Rank #${dev.rank} in the city. ${CITY_RANK_DESCRIPTION}`}
+                  >
+                    #{dev.rank} in the city
+                  </div>
+                  <p className="mx-auto mt-2 max-w-md text-xs leading-relaxed text-muted normal-case sm:mx-0">
+                    {CITY_RANK_DESCRIPTION}
+                  </p>
+                </>
               )}
 
               {/* District badge */}

--- a/src/lib/city-rank.ts
+++ b/src/lib/city-rank.ts
@@ -1,0 +1,6 @@
+export const CITY_RANK_DESCRIPTION =
+  "Global position in Git City, sorted by total GitHub contributions and recalculated periodically.";
+
+export const CITY_RANK_SHORT_DESCRIPTION = "Rank is based on total GitHub contributions.";
+
+export const CITY_RANK_EMAIL_LABEL = "City rank (by contributions)";


### PR DESCRIPTION
## What does this PR do?

Adds a short, shared explanation of what City Rank means and reuses it where rank is currently shown without enough context.

Changes:

- add `src/lib/city-rank.ts` with shared rank copy
- show the explanation under the rank badge on `/dev/[username]`, with `title` and `aria-label` on the badge
- clarify weekly and monthly digest labels/body text so email recipients understand rank is based on total GitHub contributions

## Related issue

Closes #71

## Screenshots

Local verification on `/dev/dev_001`:

![Local screenshot showing the City Rank helper text](https://raw.githubusercontent.com/therunnas/git-city/artifact-pr-109-screenshot/artifacts/pr-109-after-local-crop.png)

The Vercel preview currently requires maintainer authorization because this PR comes from a fork.

## Checklist

- [ ] `npm run lint` passes - full repo lint currently fails on pre-existing baseline errors outside this PR
- [x] Tested locally - scoped ESLint passes on the changed files and the profile page renders the helper text
- [x] No secrets or .env values committed