### PR TITLE
fix: bypass Next.js fetch cache for GitHub contributions API

### DIFF
--- a/src/app/api/dev/[username]/route.ts
+++ b/src/app/api/dev/[username]/route.ts
@@ -240,6 +240,7 @@ async function refreshDeveloper(
         ...(cached.github_etag ? { "If-None-Match": String(cached.github_etag) } : {}),
       },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      cache: "no-store",
     },
   );
 
@@ -255,7 +256,7 @@ async function refreshDeveloper(
     fetchExpandedGitHubData(login),
     fetch(
       `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=pushed&per_page=100&page=1`,
-      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), cache: "no-store" },
     ),
   ]);
 
@@ -267,7 +268,7 @@ async function refreshDeveloper(
   if (repos.length >= 100) {
     const page2Res = await fetch(
       `https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=pushed&per_page=100&page=2`,
-      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), cache: "no-store" },
     );
     if (page2Res.ok) {
       const page2: RepoItem[] = await page2Res.json();

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -134,6 +134,7 @@ export async function fetchExpandedGitHubData(login: string): Promise<ExpandedGi
       },
       body: JSON.stringify({ query, variables: { login } }),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      cache: "no-store",
     });
 
     if (!res.ok) return null;
@@ -248,7 +249,7 @@ export async function fetchGitHubDeveloperData(
 
   const userRes = await fetch(
     `https://api.github.com/users/${encodeURIComponent(login)}`,
-    { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+    { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), cache: "no-store" },
   );
 
   if (!userRes.ok) {
@@ -269,7 +270,7 @@ export async function fetchGitHubDeveloperData(
     fetchExpandedGitHubData(resolvedLogin),
     fetch(
       `https://api.github.com/users/${encodeURIComponent(resolvedLogin)}/repos?sort=pushed&per_page=100&page=1`,
-      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), cache: "no-store" },
     ),
   ]);
 
@@ -286,7 +287,7 @@ export async function fetchGitHubDeveloperData(
   if (repos.length >= 100) {
     const page2Res = await fetch(
       `https://api.github.com/users/${encodeURIComponent(resolvedLogin)}/repos?sort=pushed&per_page=100&page=2`,
-      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), cache: "no-store" },
     );
     if (page2Res.ok) {
       repos = repos.concat(await page2Res.json());


### PR DESCRIPTION
### What this PR does
This PR fixes an issue where the user's GitHub contribution count would remain stale even after using the Loadout refresh functionality or returning to GitCity later. 

### Root Cause
By default, Next.js (App Router) aggressively caches `fetch` requests across the server, including POST requests to external APIs like the GitHub GraphQL API. Because of this, the background refresh job (`refreshDeveloper`) was continually receiving and saving the exact same cached contribution data from the user's initial login, rather than hitting GitHub's servers for fresh data.

### Solution
- Added `cache: "no-store"` to the `fetch` call for `https://api.github.com/graphql` in `src/lib/github-api.ts`.
- Added `cache: "no-store"` to the repository list `fetch` calls in `src/lib/github-api.ts` and `src/app/api/dev/[username]/route.ts` to ensure users' repository stats are also kept strictly up to date.

This forces Next.js to bypass its internal data cache, ensuring GitCity successfully retrieves the latest GitHub data on every background refresh.

Closes #112
