### PR TITLE
🐛fix : Pause Resume loop on spacebar hold removed.

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -848,6 +848,7 @@ function VehicleFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = f
     const FLIGHT_KEYS = new Set(["KeyW", "KeyA", "KeyS", "KeyD", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "ShiftLeft", "ShiftRight"]);
 
     const down = (e: KeyboardEvent) => {
+      if (e.repeat) return;
       keys.current[e.code] = true;
       if (e.code === "Escape") {
         if (!paused.current) {


### PR DESCRIPTION
There was a repetition of the keyboard event down in CityCanvas for pausing and resuming on spacebar hold in flymode.

## What does this PR do?

It was a oneliner, repeat check on the keyboard event and returning on it was enough.

Fixes https://github.com/srizzon/git-city/issues/126

## Checklist

- [✔️ ] `npm run lint` passes for my changed part atleast 
- [✔️ ] Tested locally
- [ ✔️] No secrets or .env values committed
