### PR TITLE
🐛 fix : speed not updating in UI fixed

### DIFF
--- a/src/components/CityCanvas.tsx
+++ b/src/components/CityCanvas.tsx
@@ -1153,9 +1153,9 @@ function VehicleFlight({ onExit, onHud, onPause, pauseSignal = 0, hasOverlay = f
     hudTimer.current += dt;
     if (hudTimer.current > 0.25) {
       hudTimer.current = 0;
-      lastHudSpeed.current = Math.round(flySpeed.current);
+      lastHudSpeed.current = Math.round(actualSpeed);
       lastHudAlt.current = Math.round(pos.current.y);
-      onHud(flySpeed.current, pos.current.y, pos.current.x, pos.current.z, yaw.current);
+      onHud(actualSpeed, pos.current.y, pos.current.x, pos.current.z, yaw.current);
     }
   });
 


### PR DESCRIPTION
## What does this PR do?

The Speed change was not being reflected in UI Topbar upon acceleration. that has been fixed.

the onHud prop / function passed to cityCanvas to update the properties like the current speed and the positions were not getting passed the correct values in VehicleFlight. Instead of the current speed, the base speed was being passed, so now actualSpeed has been passed. And for pause, 0 was passed explicitly. so its now working for four different speeds, base Speed 55, accerelated speed, slow down speed, flymode stopped speed (zero).

<!-- Link to issue: Fixes #123 -->
Fixes https://github.com/srizzon/git-city/issues/125

## Screenshots
<img width="1918" height="876" alt="Screen Recording 2026-07-15 150107 - frame at 0m17s" src="https://github.com/user-attachments/assets/5707b93d-75c1-4886-b710-699cd7ce8289" />
<img width="1918" height="876" alt="Screen Recording 2026-07-15 150107 - frame at 0m11s" src="https://github.com/user-attachments/assets/fc5e3369-c9a2-4a80-8cba-d54d7c3162be" />
<img width="1918" height="876" alt="Screen Recording 2026-07-15 150107 - frame at 0m7s" src="https://github.com/user-attachments/assets/b3ed1305-36fa-4cb7-a363-2cfdf1ff95f3" />
<img width="1918" height="876" alt="Screen Recording 2026-07-15 150107 - frame at 0m6s" src="https://github.com/user-attachments/assets/c2364621-2fa3-4ee7-96c1-e217c819e86c" />

## Checklist

- [✔️ ] `npm run lint` passes
- [ ✔️ ] Tested locally
- [ ✔️ ] No secrets or .env values committed
